### PR TITLE
chg: Move gk band calculation into separate class

### DIFF
--- a/cpp/test/libstmpcttest/gk_tests.cpp
+++ b/cpp/test/libstmpcttest/gk_tests.cpp
@@ -147,62 +147,45 @@ TEST(gk, type_traits) {
         std::is_nothrow_move_assignable<gk<minimal_number_type>>::value);
 }
 
-// TODO: Re-enable internal implementation tests
-/*
-
-// This is a friend class to stmpct::gk and provides methods
-// to allow access to private members of gk from unit tests.
-class gk_unit_tests
+static std::vector<int> construct_band_lookup(int two_epsilon_n)
 {
-public:
-    typedef typename gk::tuples_t tuples_t;
-    static std::vector<int> construct_band_lookup(int i) { return
-gk::construct_band_lookup(i); } static double epsilon(const gk& g) { return
-g.m_epsilon; } static int max_band() { return gk::MAX_BAND; } static int n(const
-gk& g) { return g.m_n; } static int one_over_2e(const gk& g) { return
-g.m_one_over_2e; } static gk::tuples_t S(const gk& g) { return g.m_S; }
-};
-
-TEST(gk, construct_band_lookup)
-{
-    { std::vector<int> v{0}; BOOST_TEST(gk_unit_tests::construct_band_lookup(0)
-== v); } { std::vector<int> v{gk_unit_tests::max_band(), 0};
-BOOST_TEST(gk_unit_tests::construct_band_lookup(1) == v); } { std::vector<int>
-v{gk_unit_tests::max_band(), 1, 0};
-BOOST_TEST(gk_unit_tests::construct_band_lookup(2) == v); } { std::vector<int>
-v{gk_unit_tests::max_band(), 3, 3, 3, 3, 2, 2, 1, 0};
-BOOST_TEST(gk_unit_tests::construct_band_lookup(8) == v); } { std::vector<int>
-v{gk_unit_tests::max_band(), 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 2, 2, 1, 0};
-BOOST_TEST(gk_unit_tests::construct_band_lookup(16) == v); } { std::vector<int>
-v{gk_unit_tests::max_band(), 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3,
-3, 3, 3, 2, 2, 1, 1, 0}; BOOST_TEST(gk_unit_tests::construct_band_lookup(25) ==
-v); }
+    gk_bands bands(two_epsilon_n);
+    std::vector<int> result;
+    for (int i = 0; i <= two_epsilon_n; ++i) {
+        result.push_back(bands[i]);
+    }
+    return result;
 }
 
-TEST(gk, inner_state)
-{
-    int seq[] = {11, 20, 18, 5, 12, 6, 3, 2, 1, 8, 14, 19, 15, 4, 10, 7, 9, 13,
-16, 17}; gk g(0.1); for (int i = 0; i < ARRAYSIZE(seq); ++i) g.insert(seq[i]);
-    ASSERT_TRUE_EQUAL(gk_unit_tests::epsilon(g), 0.1);
-    ASSERT_TRUE_EQUAL(gk_unit_tests::one_over_2e(g), 5);
-    gk_unit_tests::tuples_t expectedS {
-        { 1, 1, 0 },
-        { 3, 2, 0 },
-        { 5, 2, 0 },
-        { 7, 1, 2 },
-        { 8, 2, 0 },
-        { 9, 1, 2 },
-        { 11, 2, 0 },
-        { 12, 1, 0 },
-        { 13, 1, 2 },
-        { 14, 1, 1 },
-        { 16, 1, 2 },
-        { 17, 1, 2 },
-        { 18, 2, 0 },
-        { 20, 2, 0 },
-    };
-    BOOST_TEST(gk_unit_tests::S(g) == expectedS);
-    ASSERT_TRUE_EQUAL(gk_unit_tests::n(g), ARRAYSIZE(seq));
+TEST(gk_bands, array_index) {
+    {
+        std::vector<int> expected{0};
+        std::vector<int> actual = construct_band_lookup(0);
+        ASSERT_EQ(actual, expected);
+    }
+    {
+        std::vector<int> expected{std::numeric_limits<int>::max(), 0};
+        std::vector<int> actual = construct_band_lookup(1);
+        ASSERT_EQ(actual, expected);
+    }
+    {
+        std::vector<int> expected{std::numeric_limits<int>::max(), 1, 0};
+        std::vector<int> actual = construct_band_lookup(2);
+        ASSERT_EQ(actual, expected);
+    }
+    {
+        std::vector<int> expected{std::numeric_limits<int>::max(), 3, 3, 3, 3, 2, 2, 1, 0};
+        std::vector<int> actual = construct_band_lookup(8);
+        ASSERT_EQ(actual, expected);
+    }
+    {
+        std::vector<int> expected{std::numeric_limits<int>::max(), 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 2, 2, 1, 0};
+        std::vector<int> actual = construct_band_lookup(16);
+        ASSERT_EQ(actual, expected);
+    }
+    {
+        std::vector<int> expected{std::numeric_limits<int>::max(), 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 2, 2, 1, 1, 0};
+        std::vector<int> actual = construct_band_lookup(25);
+        ASSERT_EQ(actual, expected);
+    }
 }
-
-*/


### PR DESCRIPTION
In preparation to optimize how gk band calculation is done, move
band construction into a separate class with a set of unit tests.