### PR TITLE
new: Significantly speed up gk for small epsilon

### DIFF
--- a/cpp/src/gk.hpp
+++ b/cpp/src/gk.hpp
@@ -15,32 +15,28 @@ namespace stmpct {
 // on the fly
 class gk_bands {
   private:
-    std::vector<int> _bands;
-
+    int _two_epsilon_n;
   public:
-    gk_bands(int two_epsilon_n) : _bands(two_epsilon_n + 1) {
-        _bands[0] =
-            std::numeric_limits<int>::max(); // delta = 0 is its own band
-        _bands[two_epsilon_n] =
-            0; // delta = two_epsilon_n is band 0 by definition
+    gk_bands(int two_epsilon_n) : _two_epsilon_n(two_epsilon_n) {}
 
-        for (int alpha = 1; alpha <= ceil(log2(two_epsilon_n)); ++alpha) {
-            int two_alpha_minus_1 = (1 << (alpha - 1));
-            int two_alpha = two_alpha_minus_1 << 1;
-            int lower = two_epsilon_n - two_alpha - (two_epsilon_n % two_alpha);
+    int operator[](int delta) const {
+        if (delta == _two_epsilon_n)
+            return 0; // delta = two_epsilon_n is band 0 by definition
+        else if (delta == 0)
+            return std::numeric_limits<int>::max(); // delta = 0 is its own band
+
+        int alpha = 1;
+        for (;;) {
+            int two_alpha = (1 << alpha);
+            int lower = _two_epsilon_n - two_alpha - (_two_epsilon_n % two_alpha);
             if (lower < 0)
                 lower = 0;
-            int upper = two_epsilon_n - two_alpha_minus_1 -
-                        (two_epsilon_n % two_alpha_minus_1);
-            for (int i = lower + 1; i <= upper; ++i) {
-                _bands[i] = alpha;
-            }
+            int two_alpha_minus_1 = (1 << (alpha - 1));
+            int upper = _two_epsilon_n - two_alpha_minus_1 - (_two_epsilon_n % two_alpha_minus_1);
+            if (delta >= lower + 1 && delta <= upper)
+                return alpha;
+            ++alpha;
         }
-    }
-
-    int operator[](std::vector<int>::size_type indx) const {
-        assert(indx >= 0 && indx < _bands.size());
-        return _bands[indx];
     }
 };
 

--- a/cpp/test/libstmpcttest/gk_tests.cpp
+++ b/cpp/test/libstmpcttest/gk_tests.cpp
@@ -157,7 +157,7 @@ static std::vector<int> construct_band_lookup(int two_epsilon_n)
     return result;
 }
 
-TEST(gk_bands, array_index) {
+TEST(gk_bands, indexing_operator) {
     {
         std::vector<int> expected{0};
         std::vector<int> actual = construct_band_lookup(0);


### PR DESCRIPTION
Speed up gk for small epsilons by computing compression bands on the fly
rather than precomputing them.  This results in an approximate 25 times
speedup for epsilon = 0.1.

Before:

```
2021-12-22T14:49:23-06:00
Running /home/sengelha/.cache/bazel/_bazel_sengelha/96bd37d8c4611ae46e087160c1a47334/execroot/__main__/bazel-out/k8-opt/bin/cpp/benchmark
Run on (8 X 3096 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.65, 0.53, 0.35
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
gk e=0.1 n=1000000 sorted         18789311886 ns   18789108600 ns            1 Rate=53.2223k/s
gk e=0.01 n=1000000 sorted         241657813 ns    241656933 ns            3 Rate=1.37937M/s
gk e=0.001 n=1000000 sorted        458908319 ns    458906950 ns            2 Rate=1089.55k/s
```

After:

```
2021-12-22T14:50:18-06:00
Running /home/sengelha/.cache/bazel/_bazel_sengelha/96bd37d8c4611ae46e087160c1a47334/execroot/__main__/bazel-out/k8-opt/bin/cpp/benchmark
Run on (8 X 3096 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.74, 0.58, 0.38
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
gk e=0.1 n=1000000 sorted           17992271 ns     17992321 ns           38 Rate=1.46261M/s
gk e=0.01 n=1000000 sorted          66318772 ns     66318518 ns           11 Rate=1.37079M/s
gk e=0.001 n=1000000 sorted        477852821 ns    477853300 ns            2 Rate=1046.35k/s
```